### PR TITLE
ci: downgrade to jdk17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '17'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
       - name: Build with Gradle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: '17'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
       - name: Publish


### PR DESCRIPTION
JDK21 emits generic metadata that older D8 versions don't like:
https://r8.googlesource.com/r8/+/61f8adfa61ba576d82badc753cbd7e8d571ad6d5

We'll need to stay on JDK17 as long as we want to support AGP versions older than 8.0.2.