### PR TITLE
chore: cleanup on aidl 5

### DIFF
--- a/observer-interface/build.gradle.kts
+++ b/observer-interface/build.gradle.kts
@@ -7,11 +7,6 @@ android {
     namespace = "wtf.emulator.observer.itf"
     compileSdk = 34
 
-    aidlPackagedList(
-        "wtf.emulator.observer.DescriptionWrapper",
-        "wtf.emulator.observer.RemoteRunListenerService",
-    )
-
     defaultConfig {
         minSdk = 21
     }

--- a/test-runtime-android/build.gradle.kts
+++ b/test-runtime-android/build.gradle.kts
@@ -11,10 +11,6 @@ android {
         minSdk = 21
     }
 
-    buildFeatures {
-        aidl = true
-    }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Get rid of a few unnecessary bits in Gradle files:

- `aidlPackagedList` whitelist isn't really needed, it'll package everything without it as well
- `test-runtime-android` doesn't need `buildFeatures.aidl`