### PR TITLE
fix: drop test events during orchestrator test collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ androidTestImplementation("wtf.emulator:test-runtime-android:0.2.0")
 
 Add the following to your `build.gradle` file(s):
 
-```kotlin
+```groovy
 androidTestImplementation 'wtf.emulator:test-runtime-android:0.2.0'
 ```

--- a/test-runtime-android/src/main/java/wtf/emulator/RunListenerServiceConnection.java
+++ b/test-runtime-android/src/main/java/wtf/emulator/RunListenerServiceConnection.java
@@ -7,7 +7,10 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.os.Bundle;
 import android.os.IBinder;
+
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.runner.notification.RunListener;
 
@@ -28,6 +31,17 @@ final class RunListenerServiceConnection extends RunListener implements ServiceC
     }
 
     public void bindToService() {
+        Bundle instrumentationArguments = InstrumentationRegistry.getArguments();
+
+        // go to NO_OP if we're running for orchestrator test collection
+        String listTestsForOrchestrator = instrumentationArguments.getString("listTestsForOrchestrator");
+        if ("true".equals(listTestsForOrchestrator)) {
+            logd("AJUR is collecting tests for orchestrator, skipping run listener");
+            runListenerService = NO_OP_SERVICE;
+            serviceConnectionLatch.countDown();
+            return;
+        }
+
         Intent intent = new Intent();
         intent.setComponent(new ComponentName("wtf.emulator.observer", "wtf.emulator.observer.RunListenerService"));
 


### PR DESCRIPTION
Drop test listener events when running in orchestrator test collection mode. This fixes the case of there being two separate videos per test - one "empty" video for the first test collection invoke and then a real video once the test actually runs.