### PR TITLE
chore: cooldown for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
   schedule:
     interval: "daily"
     time: "06:00"
+  cooldown:
+    default-days: 7
 - package-ecosystem: "gradle"
   directory: "/"
   open-pull-requests-limit: 30
   schedule:
     interval: "daily"
     time: "06:00"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
No need to be on the bleeding edge